### PR TITLE
Remove await and timeout from Worker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
 
 organization := "givers.moonlight"
 name := "play-moonlight"
-version := "0.1.2"
+version := "0.1.3"
 parallelExecution in Test := false
 
 publishMavenStyle := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.7

--- a/src/main/scala/givers/moonlight/Worker.scala
+++ b/src/main/scala/givers/moonlight/Worker.scala
@@ -10,10 +10,6 @@ import scala.concurrent.{Await, Future}
 
 abstract class Worker[Param <: Job](implicit jsonFormat: OFormat[Param]) {
 
-  val DEFAULT_FUTURE_TIMEOUT = Duration.apply(30, TimeUnit.SECONDS)
-
-  protected[this] def await[T](future: Future[T]): T = Await.result(future, DEFAULT_FUTURE_TIMEOUT)
-
   def run(job: BackgroundJob): Unit = {
     run(
       param = jsonFormat.reads(Json.parse(job.paramsInJsonString)).get,

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.7


### PR DESCRIPTION
We remove it because we can't possibly know what the right timeout for our users is