### PR TITLE
Add max error for exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please apply the SQLs to your database.
 
 ```
 resolvers += Resolver.bintrayRepo("givers", "maven")
-libraryDependencies += "givers.moonlight" %% "play-moonlight" % "0.2.0"
+libraryDependencies += "givers.moonlight" %% "play-moonlight" % "0.3.0"
 ```
 
 The artifacts are hosted here: https://bintray.com/givers/maven/play-moonlight
@@ -92,12 +92,18 @@ Create a module with defined `WorkerSpec`:
 ```
 package modules
 
-import givers.moonlight.Moonlight
+import givers.moonlight.{Config, Moonlight}
 import play.api.{Configuration, Environment}
 
 class MoonlightModule extends play.api.inject.Module {
   def bindings(environment: Environment, configuration: Configuration)  = Seq(
-    bind[Moonlight].toInstance(new Moonlight(SimpleWorkerSpec))
+    bind[Moonlight].toInstance(new Moonlight(
+      // When 3 errors occurs, Moonlight will exit. This is for avoiding being stuck in error repetitively.
+      // For example, in our case, on Heroku, when Moonlight runs on a bad machine, it will stop by itself and be
+      // started on a good machine.
+      config = Config(maxErrorCountToKillOpt = Some(3),
+      workers = Seq(SimpleWorkerSpec)
+    ))
   )
 }
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
 
 organization := "givers.moonlight"
 name := "play-moonlight"
-version := "0.2.1"
+version := "0.3.0"
 parallelExecution in Test := false
 
 publishMavenStyle := true

--- a/src/test/scala/givers.moonlight/MainIntegrationSpec.scala
+++ b/src/test/scala/givers.moonlight/MainIntegrationSpec.scala
@@ -23,7 +23,7 @@ object MainIntegrationSpec extends BaseSpec {
       )))
       .bindings(new Module {
         override def bindings(environment: Environment, configuration: Configuration) = Seq(
-          bind[Moonlight].toInstance(new Moonlight(SimpleWorker))
+          bind[Moonlight].toInstance(new Moonlight(Config(maxErrorCountToKillOpt = None), Seq(SimpleWorker)))
         )
       })
       .in(Mode.Test)

--- a/test-project/app/worker/MoonlightModule.scala
+++ b/test-project/app/worker/MoonlightModule.scala
@@ -1,10 +1,10 @@
 package worker
 
-import givers.moonlight.Moonlight
+import givers.moonlight.{Config, Moonlight}
 import play.api.{Configuration, Environment}
 
 class MoonlightModule extends play.api.inject.Module {
   def bindings(environment: Environment, configuration: Configuration)  = Seq(
-    bind[Moonlight].toInstance(new Moonlight(SimpleWorkerSpec))
+    bind[Moonlight].toInstance(new Moonlight(Config(maxErrorCountToKillOpt = Some(3)), Seq(SimpleWorkerSpec)))
   )
 }

--- a/test-project/app/worker/SimpleWorkerSpec.scala
+++ b/test-project/app/worker/SimpleWorkerSpec.scala
@@ -25,5 +25,6 @@ class SimpleWorker @Inject()() extends Worker[SimpleWorkerSpec.Job] {
   def run(param: SimpleWorkerSpec.Job, job: BackgroundJob): Unit = {
     println(s"Process data: ${param.data}")
     Thread.sleep(10000)
+    throw new Exception("Fake error")
   }
 }

--- a/test-project/conf/logback.xml
+++ b/test-project/conf/logback.xml
@@ -1,0 +1,13 @@
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%level %date{HH:mm:ss} %logger{15} - %message%n%xException{10}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+


### PR DESCRIPTION
We've seen Moonlight stuck on the same timeout error on different tasks for several hours, and restarting Moonlight solves the problem.

We don't exactly know the root cause. I think it's just a bad machine.

This mechanism allows Moonlight to be moved to a different host when running on Heroku.